### PR TITLE
Ensure shared libraries have os-specific suffix

### DIFF
--- a/test/fortran_dynamic_loader/CMakeLists.txt
+++ b/test/fortran_dynamic_loader/CMakeLists.txt
@@ -1,4 +1,9 @@
-add_executable (test_fortran_dynamic_loader test_fortran_dynamic_loader.F90)
+configure_file(test_fortran_dynamic_loader.F90.in
+  test_fortran_dynamic_loader.F90
+  @ONLY)
+
+add_executable (test_fortran_dynamic_loader
+  ${CMAKE_CURRENT_BINARY_DIR}/test_fortran_dynamic_loader.F90)
 target_link_libraries(test_fortran_dynamic_loader petaca)
 add_test(fortran_dynamic_loader test_fortran_dynamic_loader)
 

--- a/test/fortran_dynamic_loader/test_fortran_dynamic_loader.F90.in
+++ b/test/fortran_dynamic_loader/test_fortran_dynamic_loader.F90.in
@@ -33,7 +33,7 @@ contains
 
     !! Load the C math library libm.so and calculate the cube root
     !! of 8.0 using the function cbrtf from the library.
-    call libm%open ('libm.so', RTLD_NOW)
+    call libm%open ('libm@CMAKE_SHARED_LIBRARY_SUFFIX@', RTLD_NOW)
     call libm%func ('cbrtf', funptr)  ! cube root function
     call c_f_procpointer (funptr, fptr)
     if (fptr(8.0) /= 2.0) then
@@ -49,7 +49,7 @@ contains
     type(c_funptr)  :: funptr
     type(shlib) :: mylib
 
-    call mylib%open('./libmylib.so', RTLD_NOW)
+    call mylib%open('./libmylib@CMAKE_SHARED_LIBRARY_SUFFIX@', RTLD_NOW)
     call mylib%func ('square', funptr)  ! square function
     call c_f_procpointer (funptr, fptr)
     if (fptr(3.0) /= 9.0) then
@@ -65,7 +65,7 @@ contains
     type(shlib) :: mylib
     integer, pointer :: n
     type(c_ptr) :: ptr
-    call mylib%open('./libmylib.so', RTLD_NOW)
+    call mylib%open('./libmylib@CMAKE_SHARED_LIBRARY_SUFFIX@', RTLD_NOW)
     call mylib%sym('FORTYTWO', ptr)
     call c_f_pointer(ptr, n)
     if (n /= 42) then


### PR DESCRIPTION
Fixes #21. 

Uses `CMAKE_SHARED_LIBRARY_SUFFIX` to use correct suffix in the fortran_dynamic_loader test.  Works on my mac and on the petaca machines.

The secure_hash tests pass if I install some libraries providing the missing commands.